### PR TITLE
ci: adding required removal of run

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,10 @@ jobs:
     needs: call-test-workflow
 
     steps:
+      - name: Remove this after template
+        run: |
+          echo "Remove this step after updating your package.json with the correct information"
+          exit 1
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.RELEASE_PAT }}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@hanseltime/your-package-here",
+  "description": "add your description here",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/HanseltimeIndustries/your-repo-here.git"
+  },
   "types": "./dist/types/index.d.ts",
   "main": "./dist/cjs/index.js",
   "exports": {
@@ -42,10 +47,6 @@
     "prepack": "pinst --disable",
     "postpack": "pinst --enable",
     "release": "yarn semantic-release"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/HanseltimeIndustries/your-repo-here.git"
   },
   "version": "1.0.0",
   "publishConfig": {


### PR DESCRIPTION
# Summary

Template implementers were immediately releasing before updating the package.json. We make it fail right now to ensure the template user updates it.